### PR TITLE
rewrote some of the surface smoothing routine

### DIFF
--- a/nilearn/surface/surface.py
+++ b/nilearn/surface/surface.py
@@ -1011,52 +1011,155 @@ def check_surface(surface):
                                      surface.data)
     return Surface(mesh, data)
 
+def compute_adjacency_matrix(surface, values='ones', dtype=None):
+    """Computes the adjacency matrix for a surface.
+    The adjacency matrix is a matrix with one row and one column for each vertex
+    such that the value of a cell `(u,v)` in the matrix is 1 if nodes `u` and
+    `v` are adjacent and 0 otherwise.
+
+    Parameters
+    ----------
+    surface : Surface-like
+        The surface whose adjacency matrix is to be computed.
+
+    values : { 'len' | 'invlen' | 'ones'}, optional
+        If `distances` is `'ones'` (the default), then the returned matrix
+        contains uniform values in the cells representing edges. If the value is
+        `'len'` then the cells contain the edge length of the represented
+        edge. If the value is `'invlen'`, then the the inverse of the distances
+        are returned.
+
+    dtype : numpy dtype-like or None, optional
+        The dtype that should be used for the returned sparse matrix.
+
+    Returns
+    -------
+    matrix : scipy.sparse.csr_matrix
+        A sparse matrix representing the edge relationships in `surface`.
+
+    """
+    from scipy.sparse import csr_matrix
+    surface = load_surface(surface)
+    # This is a bit of a hack to quickly find a unique set of all edges.
+    n = surface.coordinates.shape[0]
+    edges = np.vstack([surface.faces[:,[0,1]],
+                       surface.faces[:,[0,2]],
+                       surface.faces[:,[1,2]]])
+    edges = edges.astype(np.int64)
+    bigcol = edges[:,0] > edges[:,1]
+    lilcol = ~bigcol
+    edges = np.concatenate([edges[bigcol,0] + edges[bigcol,1]*n,
+                            edges[lilcol,1] + edges[lilcol,0]*n])
+    edges = np.unique(edges)
+    (u,v) = (edges // n, edges % n)
+    # Calculate distances between pairs. We use this as a weighting to make sure that
+    # smoothing takes into account the distance between each vertex neighbor
+    if values == 'len' or values == 'invlen':
+        coords = surface.coordinates
+        edge_lens = np.sqrt(np.sum((coords[u,:] - coords[v,:])**2, axis=1))
+        if dtype is None:
+            dtype = edge_lens.dtype
+        else:
+            edge_lens = edge_lens.astype(dtype)
+        if values == 'invlen':
+            edge_lens = 1 / edge_lens
+    elif values == 'ones':
+        if dtype is None:
+            edge_lens = np.ones_like(edges)
+        else:
+            edge_lens = np.ones(edges.shape, dtype=dtype)
+    else:
+        raise ValueError(f"unrecognized values argument: {values}")
+    # We can now make a sparse matrix.
+    ee = np.concatenate([edge_lens, edge_lens])
+    uv = np.concatenate([u, v])
+    vu = np.concatenate([v, u])
+    return csr_matrix((ee, (uv, vu)), shape=(n,n))
+
 def compute_vertex_neighborhoods(surface):
-    """For each vertex, compute the neighborhood defined as all the vertices that are connected by a face.
+    """For each vertex, compute the neighborhood.
+    The neighborhood is  defined as all the vertices that are connected by a
+    face.
     
     Parameters
     ----------
-    surface : Surface-like (see description)
+    surface : Surface-like
+        The surface whose vertex neighborhoods are to be computed.
     
     Returns
     -------
-    neighbors : A list of all the vertices that are connected to each vertex
-    
+    neighbors : list
+        A list of all the vertices that are connected to each vertex
     """
-    # This builds a coordiate to face dictionary 
-    # where each entry gives a list of the faces associated with that vertex
-    d = {k:[] for k in range(surface.coordinates.shape[0])}
-    for (i,(u,v,w)) in enumerate(surface.faces):
-        d[u].append(i)
-        d[v].append(i)
-        d[w].append(i)
-    
-    # This collects a list of vertices that are connected to each vertex
-    neighbors = []
-    for k in range(surface.coordinates.shape[0]):
-        neighbors.append(np.unique(surface.faces[d[k]]))
+    from scipy.sparse import find
+    matrix = compute_adjacency_matrix(surface)
+    return [find(row)[1] for row in matrix]
         
-    return neighbors
-        
-def smooth_surface_data(surface, surf_data, smooth_steps = 1, method = 'sparse', weights = None):
+def smooth_surface_data(surface, surf_data,
+                        iterations=1,
+                        distance_weights=False,
+                        vertex_weights=None,
+                        return_vertex_weights=False,
+                        center_surround_knob=0,
+                        match=None):
     """Smooth values along the surface.
     
     Parameters
     ----------
-    surface : Surface-like (see description)
+    surface : Surface-like
+        The surface on which the data `surf_data` are to be smoothed.
 
-    surf_data : Array of values at each vertex. Should be a vertics X N array. In the
-    case of fmri data, N could be number of timepoints. Each column is smoothed independently
+    surf_data : array-like
+        The array of values at each vertex that is being smoothed. This may
+        either be a vector of length `n` or a matrix with `n` rows.  In the case
+        of fMRI data, `n` could be the number of timepoints. Each column is
+        smoothed independently.
 
-    smooth_steps : How many times to repeat the smoothing operation. Defaults to 1 step
+    iterations : positive int, optional
+        The number of times to repeat the smoothing operation. Defaults to 1
+        iteration.
 
-    method : Whether to use scipy sparse matrices (default)
+    distance_weights : boolean, optional
+        Whether to add distance-based weighting to the smoothing. With such
+        weights, the value calculated for each vertex each iteration is the
+        weighted sum of neighboring vertices where the weight on each neighbor
+        is the inverses of the distances to it.
 
-    weights : Whether to add weighting to the smoothing. Default is none
+    vertex_weights : array-like or None, optional
+        A vector of weights, one per vertex. These weights are normalizd and
+        applied to the smoothing after the application of center-surround
+        weights.
+
+    return_vector_weights : boolean, optional
+        If `True` then `(smoothed_data, smoothed_vertex_weights)` are returned.
+        The default is `False`.
+
+    center_surround_knob : float, optional
+        The relative weighting of the center and the surround in each iteration
+        of the smoothing. If the value of the knob is `k`, then the total weight
+        of vertices that are neighbors of a given vertex (the vertex's surround)
+        is `2**k` times the weight of the vertex itself (the center). A value of
+        0 (the default) means that, in each smoothing iteration, each vertex is
+        updated wiith the average of its value and the average value of its
+        neighbors. A value of `-inf` results in no smoothing because the entire
+        weight is on the center, so each vertex is updated with its own value. A
+        value of `inf` results in each vertex being updated with the average of
+        its neighbors without including its own value.
+
+    match : { None | 'sum' | 'mean' | 'var' | 'dist' }, optional
+        What properties of the input data should be matched in the output data.
+        The default of `None` indicates that the smoothed output should be
+        returned without transformation. If the value is `'sum'`, then the
+        output is rescaled to have the same sum as `surf_data`. If the value is
+        `'mean'`, then the output is shifted to match the mean of the input. If
+        the value is `'var'` or `'std'`, then the variance of the output is
+        matched. Finally, if the value iis `'dist'`, then the mean and the
+        variance are matched.
     
     Returns
     -------
-    surf_data_smooth : Array of smoothed values at each vertex
+    surf_data_smooth : array
+        The array of smoothed values at each vertex.
 
     Examples
     -------
@@ -1064,60 +1167,70 @@ def smooth_surface_data(surface, surf_data, smooth_steps = 1, method = 'sparse',
     >>> fsaverage = datasets.fetch_surf_fsaverage('fsaverage')
     >>> white_left = surface.load_surf_mesh(fsaverage.white_left)
     >>> curv = surface.load_surf_data(fsaverage.curv_left)
-    >>> curv_smooth = surface.smooth_surface_data(surface = white_left, surf_data = curv, smooth_steps=50)
+    >>> curv_smooth = surface.smooth_surface_data(surface=white_left, surf_data=curv, iterations=50)
     >>> plotting.plot_surf(white_left, surf_map = curv_smooth)
-    
+
     """
-    if method == 'sparse':
-        from scipy.sparse import csr_matrix
-
-        # This is a bit of a hack to quickly find a unique set of all edges.
-        n = surface.coordinates.shape[0]
-        edges = np.vstack([surface.faces[:,[0,1]], surface.faces[:,[0,2]], surface.faces[:,[1,2]]])
-        edges = edges.astype(np.int64)
-        bigcol = edges[:,0] > edges[:,1]
-        lilcol = ~bigcol
-        edges = np.concatenate([edges[bigcol,0] + edges[bigcol,1]*n,
-                                edges[lilcol,1] + edges[lilcol,0]*n])
-        edges = np.unique(edges)
-        (u,v) = (edges // n, edges % n)
-
-        # Calculate distances between pairs. We use this as a weighting to make sure that
-        # smoothing takes into account the distance between each vertex neighbor
-        if weights == 'distance':
-            edge_lens = np.sqrt(np.sum((surface.coordinates[u,:] - surface.coordinates[v,:])**2, axis=1))
-        else:
-            edge_lens = np.ones_like(edges)
-
-        # We can now make a sparse matrix.
-        ee = np.concatenate([edge_lens, edge_lens])
-        uv = np.concatenate([u, v])
-        vu = np.concatenate([v, u])
-        matrix = csr_matrix((1 / ee, (uv, vu)), shape=(n,n))
-        # Normalize it.
-        rowsums = matrix.sum(axis=1)
-        matrix = matrix.multiply(1 / rowsums)
-
-        for ii in range(smooth_steps):
-            surf_data = np.array(matrix.dot(surf_data)).flatten()
-
-        surf_data_smooth = surf_data
-    
+    from scipy.sparse import diags
+    surface = load_surface(surface)
+    # First, calculate the center and surround weights for the
+    # center-surround knob.
+    t = center_surround_knob
+    center_weight = 1 / (1 + np.exp2(-t))
+    surround_weight = 1 - center_weight
+    if surround_weight == 0:
+        # There's nothing to do in this case.
+        return np.array(surf_data)
+    # Calculate the adjacency matrix.
+    matrix = compute_adjacency_matrix(surface, distances=distance_weights)
+    # If there are vertex weights, get them ready.
+    if vertex_weights:
+        w = np.array(vertex_weights)
+        w /= np.sum(w)
     else:
-    
-        neighbors = compute_vertex_neighborhoods(surface)
-        dists = [np.sqrt(np.sum((surface.coordinates[neis] - surface.coordinates[center])**2, axis=1))
-                for (center, neis) in enumerate(neighbors)]
-        nei_weights = [1 / d for d in dists]
-        # Loop over smoothing steps
-        for s in range(smooth_steps):
-            surf_data_smooth = np.zeros_like(surf_data)
-            # Loop over vertices and average each datapoint with its neighbors
-            for k in range(surf_data.shape[0]):
-                w = nei_weights[k]
-                # If there are multiple timepoints averaging is done separately for each timepoint
-                surf_data_smooth[k] = np.sum(surf_data[neighbors[k]] * w, axis=0) / np.sum(w)
-            surf_data = surf_data_smooth
-    
-            
-    return surf_data_smooth
+        w = np.ones(len(matrix))
+    # We need to normalize the matrix columns, and we can do this now by
+    # normalizing everything but the diagonal to the surround weight, then
+    # adding the center weight along the diagonal.
+    colsums = matrix.sum(axis=1)
+    colsums = np.asarray(colsums).flatten()
+    matrix = matrix.multiply(surround_weight / colsums[:,None])
+    # Add in the diagonal.
+    matrix.setdiag(center_weight)
+    # Run the iteratioons of smooothing.
+    n = len(surf_data)
+    data = np.hstack([np.reshape(surf_data, (n,-1)), w[:,None]])
+    for ii in range(iterations):
+        w = data[:,-1]
+        w /= np.sum(w)
+        data = matrix.dot(diags(w, format='csc')).dot(data)
+    # Convert back into numpy array.
+    (data, w) = (data[:,:-1], data[:,-1])
+    data = np.reshape(np.asarray(data), np.shape(surf_data))
+    # Rescale it if needed.
+    if match == 'sum':
+        sum0 = np.nansum(surf_data, axis=0)
+        sum1 = np.nansum(data, axis=0)
+        data = data * (sum0 / sum1)
+    elif match == 'mean':
+        mu0 = np.nansum(surf_data, axis=0)
+        mu1 = np.nansum(data, axis=0)
+        data = data + (mu0 - mu1)
+    elif match in ('var','std','variance','stddev','sd'):
+        std0 = np.nanstd(surf_data, axis=0)
+        std1 = np.nanstd(data, axis=0)
+        mu1 = np.nanmean(data, axis=0)
+        data = (data - mu1) * (std0 / std1) + mu1
+    elif match in ('dist','meanvar','meanstd','meansd'):
+        std0 = np.nanstd(surf_data, axis=0)
+        std1 = np.nanstd(data, axis=0)
+        mu0 = np.nanmean(surf_data, axis=0)
+        mu1 = np.nanmean(data, axis=0)
+        data = (data - mu1) * (std0 / std1) + mu0
+    elif match is not None:
+        raise ValueError(f"invalid match argument: {match}")
+    if return_vertex_weights:
+        w /= np.sum(w)
+        return (data, w)
+    else:
+        return data


### PR DESCRIPTION
Hi Jason—this is an update to the surface smoothing code that modularizes things a bit better and adds a knob for the center versus surround vertices. It makes some other improvements also, but let's talk through them next week.

Regarding the issue of the sum of the smoothed data changing—I'm back to believing that this isn't what you want. Basically, if you want the sum to stay the same, you have to normalize the sparse matrix columns—this ensures that every vertex is contributing its entire value to the new smoothed property vector, which ensures that the sum of that vector is the same. However, it doesn't result in a smooth property. To understand this, imagine a mesh that's organized like a pinwheel: there are 20 vertices on the perimeter of a circle and one vertex at the center of the circle that is connected to every perimeter vertex while perimeter vertices are connected to the center vertex and the vertices just clockwise/counterclockwise of them. If you smooth a property in which the center vertex starts with a value of 0 and the outer vertices start with a value of 1, each of the outer vertices will contribute a value of 1/3 to each of it's neighbors, meaning that the perimeter vertices each get smoothed to the value 2/3 while the central vertex gets "smoothed" to the value 20/3.

On the other hand, if you normalize the rows of the matrix, then you are guaranteeing each vertex's smoothed value draws one vertex-worth of property into its new smoothed value, but the sum of values isn't guaranteed to stay the same. In the same pinwheel graph, imagine a property where the central vertex has a value of 1 but the outer vertices have a value of 0. After one iteration of smoothing, the outer vertices will each have a value of 1/3, meaning that the sum of all the property values is now 20/3 instead of 1. However, the property will always get smoother in this case.

To deal with this, I added code to automatically force the output to match the input in terms of either its sum (multiplicative scaling), its mean (additive scaling), its variance, or its mean and variance.

This code still needs to be tested (and needs tests written) before we can push to nilearn, but we can maybe do that in a code collab meeting? I also once again removed the old/slower way of doing things—we can add it back if you want, but it's something like 100x slower, so I'm not sure if nilearn will want it included in the final pull request.